### PR TITLE
Initialize MachineState Object from dictionary/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ or
 $ python3
 >>> import machinestate
 ```
+or just for the current project
+```
+$ wget https://raw.githubusercontent.com/RRZE-HPC/MachineState/master/machinestate.py
+$ ./machinestate.py
+```
 
 The module cannot be used with Python2!
 
@@ -82,11 +87,9 @@ Usage (CLI)
 --------------------------------------------------------------------------------
 Getting usage help:
 ```
-$ machinestate -h
 usage: machinestate.py [-h] [-e] [-a] [-c] [-s] [-i INDENT] [-o OUTPUT]
-                       [-j JSON] [--configfile CONFIGFILE]
+                       [-j JSON] [--html] [--configfile CONFIGFILE]
                        [executable]
-
 
 Reads and outputs system information as JSON document
 
@@ -102,8 +105,10 @@ optional arguments:
   -i INDENT, --indent INDENT
                         indention in JSON output (default: 4)
   -o OUTPUT, --output OUTPUT
-                        save JSON to file (default: stdout)
+                        save to file (default: stdout)
   -j JSON, --json JSON  compare given JSON with current state
+  --html                generate HTML page with CSS and JavaScript embedded
+                        instead of JSON
   --configfile CONFIGFILE
                         Location of configuration file
 ```
@@ -182,6 +187,17 @@ Compare JSON file created with `machinestate.py` with current state
 ```
 $ machinestate -j oldstate.json
 ```
+
+Output the MachineState data as collapsible HTML table (with CSS and JavaScript):
+```
+$ machinestate --html
+```
+
+You can also redirekt the HTML output to a file directly:
+```
+$ machinestate --html --output machine.html
+```
+You can embedd the file in your HTML page within an `<iframe>`ö.
 
 --------------------------------------------------------------------------------
 Configuration file
@@ -275,7 +291,7 @@ Differences between Shell and Python version
 The Shell version (`shell-version/machine-state.sh`) executes some commands and
 just dumps the output to stdout.
 
-The Python version (`machine-state.py`) collects all data and outputs it in JSON
+The Python version (`machinestate.py`) collects all data and outputs it in JSON
 format. This version is currently under development.
 
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ optional arguments:
   -o OUTPUT, --output OUTPUT
                         save to file (default: stdout)
   -j JSON, --json JSON  compare given JSON with current state
+  -m, --no-meta         embed meta information in classes (recommended, default: True)
   --html                generate HTML page with CSS and JavaScript embedded
                         instead of JSON
   --configfile CONFIGFILE
@@ -282,7 +283,24 @@ $ python3
 >>> ms.generate()
 >>> ms.update()
 >>> ms == oldstate
-False
+True
+```
+In case of 'False', it reports the value differences and missing keys. For integer and float values, it compares the values with a tolerance of 20%. Be aware that if you use `oldstate.get() == ms.get()`, it uses the default `dict` comparison which does not print anything and matches exact.
+
+
+If you want to load an old state and use the class tree
+```
+$ python3
+>>> oldstate = {}           # dictionary of oldstate or
+                            # path to JSON file of oldstate or
+                            # JSON document (as string)
+                            # or a MachineState class
+                            # It has to contain the '_meta' entries
+                            # you get when calling get_json() or
+                            # get(meta=True)
+>>> ms = machinestate.MachineState.from_dict(oldstate)
+>>> ms == oldstate
+True
 ```
 
 --------------------------------------------------------------------------------

--- a/machinestate.py
+++ b/machinestate.py
@@ -2901,7 +2901,7 @@ def read_cli(cliargs):
     parser.add_argument('-o', '--output', help='save to file (default: stdout)', default=None)
     parser.add_argument('-j', '--json', help='compare given JSON with current state', default=None)
     parser.add_argument('-m', '--no-meta', action='store_false', default=True,
-                        help='embed meta information in classes (recommended, default: True)')
+                        help='do not embed meta information in classes (recommended, default: True)')
     parser.add_argument('--html', help='generate HTML page with CSS and JavaScript embedded instead of JSON', action='store_true', default=False)
     parser.add_argument('--configfile', help='Location of configuration file', default=None)
     parser.add_argument('executable', help='analyze executable (optional)', nargs='?', default=None)

--- a/machinestate.py
+++ b/machinestate.py
@@ -1441,6 +1441,7 @@ class NumaInfoHugepagesClass(InfoGroup):
 class NumaInfoClass(PathMatchInfoGroup):
     def __init__(self, node, anonymous=False, extended=False):
         super(NumaInfoClass, self).__init__(anonymous=anonymous, extended=extended)
+        self.node = node
         self.name = "NumaNode{}".format(node)
         base = "/sys/devices/system/node/node{}".format(node)
         meminfo = pjoin(base, "meminfo")

--- a/machinestate.py
+++ b/machinestate.py
@@ -2875,7 +2875,7 @@ base_css = """
   color: #444;
   cursor: pointer;
   padding: 18px;
-  width: 100%;
+  width: 98vw;
   border: none;
   text-align: left;
   outline: none;
@@ -2888,7 +2888,7 @@ base_css = """
 }
 
 .accordion:after {
-  content: '\002B';
+  content: '\\002B';
   color: #777;
   font-weight: bold;
   float: right;
@@ -2896,7 +2896,7 @@ base_css = """
 }
 
 .active:after {
-  content: "\2212";
+  content: "\\2212";
 }
 
 .panel {
@@ -2905,6 +2905,7 @@ base_css = """
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.2s ease-out;
+  width: 97vw;
 }
 
 .option {
@@ -2921,12 +2922,12 @@ base_css = """
 
 .expandable {
   background-color: #4CAF50;
-  width: 50%;
+  width: 49vw;
 }
 
 .collapsible {
   background-color: #f44336;
-  width: 50%;
+  width: 49vw;
 }
 </style>
 """

--- a/machinestate.py
+++ b/machinestate.py
@@ -595,6 +595,20 @@ class InfoGroup:
             outdict.update({inst.name : clsout})
         outdict.update(self._data)
         return outdict
+    def get_html(self):
+        s = ""
+        s += "<button class=\"accordion\">{}</button>\n".format(self.name)
+        s += "<div class=\"panel\">\n<table style=\"width:100vw\">\n"
+        for k,v in self._data.items():
+            if isinstance(v, list):
+                s += "<tr>\n\t<td style=\"width: 20%\"><b>{}:</b></td>\n\t<td>{}</td>\n</tr>\n".format(k, ", ".join([str(x) for x in v]))
+            else:
+                s += "<tr>\n\t<td style=\"width: 20%\"><b>{}:</b></td>\n\t<td>{}</td>\n</tr>\n".format(k, v)
+        for inst in self._instances:
+            s += "<tr>\n\t<td colspan=\"2\">{}</td>\n</tr>".format(inst.get_html())
+        s += "</table>\n</div>\n\n"
+        return s
+
     def get_json(self, sort=False, intend=4):
         """Get the object's and all subobjects' data as JSON document (string)"""
         outdict = self.get()
@@ -1030,6 +1044,19 @@ class MachineState(MultiClassInfoGroup):
             clsout = inst.get_config()
             outdict.update({inst.name : clsout})
         return json.dumps(outdict, sort_keys=sort, indent=intend)
+    def get_html(self):
+        s = ""
+        s += "<table style=\"width:100vw\">\n"
+#        for k,v in self._data.items():
+#            if isinstance(v, list):
+#                s += "<tr>\n\t<td>{}</td>\n\t<td>{}</td>\n</tr>\n".format(k, ", ".join([str(x) for x in v]))
+#            else:
+#                s += "<tr>\n\t<td>{}</td>\n\t<td>{}</td>\n</tr>\n".format(k, v)
+        for inst in self._instances:
+            s += "<tr>\n\t<td colspan=\"2\">{}</td>\n</tr>".format(inst.get_html())
+        s += "</table>\n\n"
+        return s
+
 
 ################################################################################
 # Configuration Classes
@@ -2711,8 +2738,9 @@ def read_cli(cliargs):
                         help='sort JSON output (default: False)')
     parser.add_argument('-i', '--indent', default=4, type=int,
                         help='indention in JSON output (default: 4)')
-    parser.add_argument('-o', '--output', help='save JSON to file (default: stdout)', default=None)
+    parser.add_argument('-o', '--output', help='save to file (default: stdout)', default=None)
     parser.add_argument('-j', '--json', help='compare given JSON with current state', default=None)
+    parser.add_argument('--html', help='generate HTML page with CSS and JavaScript embedded instead of JSON', action='store_true', default=False)
     parser.add_argument('--configfile', help='Location of configuration file', default=None)
     parser.add_argument('executable', help='analyze executable (optional)', nargs='?', default=None)
     pargs = vars(parser.parse_args(cliargs))
@@ -2786,6 +2814,146 @@ def read_config(config={"extended" : False, "anonymous" : False, "executable" : 
 
     return configdict
 
+
+base_js = """
+<script>
+var acc = document.getElementsByClassName("accordion");
+var i;
+
+for (i = 0; i < acc.length; i++) {
+  acc[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var children = this.parentNode.childNodes;
+    children.forEach(child => {
+        if(child.style) {
+    		if (child.style.maxHeight) {
+        		child.style.maxHeight = null;
+       		} else {
+	        	child.style.maxHeight = child.scrollHeight + "px";
+    	    }
+        }
+    });
+    adjust(this.parentNode);
+  });
+}
+
+var bExpand = document.getElementsByClassName("option expandable")[0];
+var bCollaps = document.getElementsByClassName("option collapsible")[0];
+
+bExpand.addEventListener("click", function() {
+	var accNonActive = Array.prototype.filter.call(acc, function(elem, i, acc) {
+		return !elem.className.includes("active");
+	});
+	for (i = accNonActive.length - 1; i >= 0; i--) {
+		accNonActive[i].click();
+	}
+});
+
+bCollaps.addEventListener("click", function() {
+	var accActive = Array.prototype.filter.call(acc, function(elem, i, acc) {
+		return elem.className.includes("active");
+	});
+	for (i = accActive.length - 1; i >= 0; i--) {
+		accActive[i].click();
+	}
+});
+
+function adjust(node) {
+	if(node.style) {
+        node.style.maxHeight = 10 * window.innerHeight + "px";
+    }
+    if(node.parentNode){
+    	adjust(node.parentNode);
+	}
+}
+</script>
+"""
+base_css = """
+<style>
+.accordion {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 18px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+  transition: 0.4s;
+}
+
+.active, .accordion:hover {
+  background-color: #ccc;
+}
+
+.accordion:after {
+  content: '\002B';
+  color: #777;
+  font-weight: bold;
+  float: right;
+  margin-left: 5px;
+}
+
+.active:after {
+  content: "\2212";
+}
+
+.panel {
+  padding: 0 18px;
+  background-color: white;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out;
+}
+
+.option {
+  float: left;
+  background-color: #555555;
+  border: none;
+  color: white;
+  padding: 15px 32px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 15px;
+}
+
+.expandable {
+  background-color: #4CAF50;
+  width: 50%;
+}
+
+.collapsible {
+  background-color: #f44336;
+  width: 50%;
+}
+</style>
+"""
+
+base_html = """
+<html>
+<head>
+<meta name "viewport" content="width=device-width, initial-scale=1">
+{css}
+</head>
+
+<body>
+<button class="option expandable">Expand all</button>
+<button class="option collapsible">Collapse all</button>
+{table}
+{script}
+</body>
+</html>
+"""
+
+def get_html(cls, css=True, js=True):
+    add_css = base_css if css is True else ""
+    add_js = base_js if js is True else ""
+    table = cls.get_html()
+    return base_html.format(table=table, css=add_css, script=add_js)
+
+
 def main():
     try:
         # Read command line arguments
@@ -2820,10 +2988,16 @@ def main():
 
     # Determine output destination
     if not cliargs["output"]:
-        print(jsonout)
+        if cliargs["html"]:
+            print(get_html(mstate))
+        else:
+            print(jsonout)
     else:
         with open(cliargs["output"], "w") as outfp:
-            outfp.write(mstate.get_json(sort=cliargs["sort"], intend=cliargs["indent"]))
+            if cliargs["html"]:
+                outfp.write(get_html(mstate))
+            else:
+                outfp.write(mstate.get_json(sort=cliargs["sort"], intend=cliargs["indent"]))
             outfp.write("\n")
     sys.exit(0)
 

--- a/machinestate.py
+++ b/machinestate.py
@@ -2844,7 +2844,7 @@ bExpand.addEventListener("click", function() {
 	var accNonActive = Array.prototype.filter.call(acc, function(elem, i, acc) {
 		return !elem.className.includes("active");
 	});
-	for (i = accNonActive.length - 1; i >= 0; i--) {
+	for (i = 0; i < accNonActive.length; i++) {
 		accNonActive[i].click();
 	}
 });

--- a/machinestate.py
+++ b/machinestate.py
@@ -1925,6 +1925,7 @@ class HugepagesClass(InfoGroup):
     def __init__(self, size, extended=False, anonymous=False):
         name = "Hugepages-{}".format(size)
         super(HugepagesClass, self).__init__(name=name, extended=extended, anonymous=anonymous)
+        self.size = size
         base = "/sys/kernel/mm/hugepages/hugepages-{}".format(size)
         self.addf("Count", pjoin(base, "nr_hugepages"), r"(\d+)", int)
         self.addf("Free", pjoin(base, "free_hugepages"), r"(\d+)", int)

--- a/tests/all_tests.py
+++ b/tests/all_tests.py
@@ -14,6 +14,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
         'test_machinestate',
         'test_repr',
         'test_config',
+        'test_fromdict',
     ]
 )
 

--- a/tests/test_fromdict.py
+++ b/tests/test_fromdict.py
@@ -15,9 +15,15 @@ class TestFromDict(unittest.TestCase):
         self.ms = machinestate.MachineState()
         self.ms.generate()
         self.ms.update()
-        self.ci = machinestate.CpuInfo()
-        self.ci.generate()
-        self.ci.update()
+        data = self.ms.get()
+        if data["OperatingSystemInfo"]["Type"] == "Linux":
+            self.ci = machinestate.CpuInfo()
+            self.ci.generate()
+            self.ci.update()
+        else:
+            self.ci = machinestate.CpuInfoMacOS()
+            self.ci.generate()
+            self.ci.update()
     def test_fromdictCompareClass(self):
         mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
         self.assertEqual(self.ms, mscopy)

--- a/tests/test_fromdict.py
+++ b/tests/test_fromdict.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Tests for from_dict() function
+"""
+
+import unittest
+import machinestate
+from tempfile import NamedTemporaryFile
+from locale import getpreferredencoding
+
+ENCODING = getpreferredencoding()
+
+class TestFromDict(unittest.TestCase):
+    def setUp(self):
+        self.ms = machinestate.MachineState()
+        self.ms.generate()
+        self.ms.update()
+        self.ci = machinestate.CpuInfo()
+        self.ci.generate()
+        self.ci.update()
+    def test_fromdictCompareClass(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms, mscopy)
+    def test_fromdictCompareDict(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms, mscopy.get())
+    def test_fromdictCompareDictMeta(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms, mscopy.get(meta=True))
+    def test_fromdictCompareJSON(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms, mscopy.get_json())
+    def test_fromdictCompareJSONFile(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        jsonfp = NamedTemporaryFile(mode="wb", delete=True)
+        jsonfp.write(bytes(mscopy.get_json(), ENCODING))
+        jsonfp.seek(0)
+        self.assertEqual(self.ms, jsonfp.name)
+        jsonfp.close()
+    def test_fromdictCompareDictDict(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms.get(), mscopy.get())
+    def test_fromdictCompareDictMetaDictMeta(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertEqual(self.ms.get(meta=True), mscopy.get(meta=True))
+    def test_fromdictCompareDictMetaDict(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms.get(meta=True))
+        self.assertNotEqual(self.ms.get(), mscopy.get(meta=True))
+    def test_fromdictLoadFaulty(self):
+        cicopy = {}
+        for k,v in self.ci.get(meta=True).items():
+            cicopy[k] = v
+        cicopy["Model"] = cicopy["Model"] - 1
+        faulty = machinestate.CpuInfo.from_dict(cicopy)
+        self.assertNotEqual(self.ci.get(), faulty.get())
+    def test_fromdictNoMeta(self):
+        #mscopy = machinestate.MachineState.from_dict(self.ms.get())
+        self.assertRaises(ValueError, machinestate.MachineState.from_dict, self.ms.get())
+    def test_fromdictClass(self):
+        mscopy = machinestate.MachineState.from_dict(self.ms)
+        self.assertEqual(self.ms, mscopy.get(meta=True))
+    def test_fromdictEmptyDict(self):
+        self.assertRaises(ValueError, machinestate.MachineState.from_dict, {})
+    def test_fromdictFaultyNoMetaDict(self):
+        faulty = { "1" : 3, "2" : 24, "5" : 45}
+        self.assertRaises(ValueError, machinestate.MachineState.from_dict, faulty)
+    def test_fromdictFaultyMetaDict(self):
+        faulty = { "1" : 3, "2" : 24, "5" : 45, "_meta" : "foobar"}
+        self.assertRaises(ValueError, machinestate.MachineState.from_dict, faulty)
+    def test_fromdictFaultyMetaMachineStateDict(self):
+        faulty = { "1" : 3, "2" : 24, "5" : 45, "_meta" : "MachineState()"}
+        mscopy = machinestate.MachineState.from_dict(faulty)
+        self.assertEqual(mscopy.get(), {})
+    def test_fromdictFaultyMetaCpuInfoDict(self):
+        self.assertRaises(ValueError, machinestate.MachineState.from_dict, self.ci.get(meta=True))

--- a/tests/test_listinfo.py
+++ b/tests/test_listinfo.py
@@ -21,6 +21,8 @@ class TestInfoGroup(InfoGroup):
     def __init__(self, ident, name=None, extended=False, anonymous=False, basepath=""):
         super(TestInfoGroup, self).__init__(extended=extended, name=name, anonymous=anonymous)
         self.name = "File{}".format(ident)
+        self.ident = ident
+        self.basepath = basepath
         path = os.path.join(basepath, "{}*".format(ident))
         files = glob.glob(path)
         self.addf("File{}".format(ident), files[0], r"(.+)")

--- a/tests/test_machinestate.py
+++ b/tests/test_machinestate.py
@@ -17,12 +17,25 @@ ENCODING = getpreferredencoding()
 class TestMachineState(unittest.TestCase):
     def test_getJson(self):
         cls = MachineState()
-        outstr = cls.get_json()
+        outstr = cls.get_json(meta=False)
         self.assertEqual(outstr, "{}")
+    def test_getJsonMeta(self):
+        cls = MachineState()
+        outstr = cls.get_json(meta=True)
+        self.assertEqual(outstr, "{\n    \"_meta\": \"MachineState()\"\n}")
     def test_CompareJson(self):
         cls = MachineState()
         cls.generate()
         cls.update()
         outstr = cls.get_json()
         self.assertNotEqual(outstr, "{}")
-        self.assertTrue(cls == outstr)
+        self.assertTrue(cls.get_json() == outstr)
+    def test_fromDictCompare(self):
+        ms = MachineState();
+        ms.generate();
+        ms.update()
+        msdict = ms.get(meta=True)
+        mscopy = MachineState.from_dict(msdict)
+        self.assertEqual(ms, mscopy)
+        self.assertEqual(ms.get(meta=False), mscopy.get(meta=False))
+        self.assertEqual(ms.get(meta=True), mscopy.get(meta=True))

--- a/tests/test_multiclassinfo.py
+++ b/tests/test_multiclassinfo.py
@@ -21,6 +21,8 @@ class TestInfoGroup(InfoGroup):
     def __init__(self, name=None, extended=False, anonymous=False, basepath="", ident=-1):
         super(TestInfoGroup, self).__init__(extended=extended, name=name, anonymous=anonymous)
         self.name = "File{}".format(ident)
+        self.basepath = basepath
+        self.ident = ident
         path = os.path.join(basepath, "{}*".format(ident))
         files = glob.glob(path)
         self.addf("File{}".format(ident), files[0], r"(.+)")

--- a/tests/test_pathmatchinfo.py
+++ b/tests/test_pathmatchinfo.py
@@ -15,7 +15,10 @@ ENCODING = getpreferredencoding()
 
 class TestPathMatchInfoGroup(InfoGroup):
     def __init__(self, ident, extended=False, anonymous=False, searchpath=""):
-        super(TestPathMatchInfoGroup, self).__init__(anonymous=anonymous, extended=extended, name="File{}".format(ident))
+        super(TestPathMatchInfoGroup, self).__init__(
+            anonymous=anonymous, extended=extended, name="File{}".format(ident))
+        self.ident = ident
+        self.searchpath = searchpath
         path = os.path.join(searchpath, "{}*".format(ident))
         files = glob.glob(path)
         self.addf("File{}".format(ident), files[0], r"(.+)")


### PR DESCRIPTION
To be able to use the `to_html` functionality from a json dump, a `MachineState` object needs to be initialized.

A basic test if this works is this round-trip:
```python
import machinestate
ms = machinestate.MachineState(); ms.generate(); ms.update()
machinestate.MachineState.from_dict(ms.get()) == ms.get()
```

Unfortunately, this required a change in the output format. Each `InfoGroup` inserts two more attributes into the returned dict: `__classname__` and `__initargs__`. This is necessary to reproduce the original objects.

Things that are still missing or need to be discussed:
- [ ] Add unit tests
- [ ] Can `__classname__` and `__initargs__` be avoided
- [ ] Could the `__init__` functions be rewritten without dependence on current environment?
- [ ] Split class configuration from constructor?