### PR TITLE
Support for MacOS on Arm64 (Apple Silicon)

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -28,8 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # let's not check MacOS for now (add `macos-latest` later)
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -51,6 +51,7 @@ jobs:
         export PATH="/usr/local/opt/gcc@14/bin":$PATH;
         export CC=gcc-14; export CXX=g++-14;
         export FC=gfortran
+        clinfo --raw --offline
     - name: Pre-Install (generic)
       run: |
         python -m pip install codecov

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-14, macos-15]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     
@@ -51,7 +51,6 @@ jobs:
         export PATH="/usr/local/opt/gcc@14/bin":$PATH;
         export CC=gcc-14; export CXX=g++-14;
         export FC=gfortran
-        clinfo --raw --offline
     - name: Pre-Install (generic)
       run: |
         python -m pip install codecov

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, macos-15]
+        os: [ubuntu-latest, macos-13, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     
@@ -44,10 +44,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install slurm slurm-client openmpi-bin clang gfortran clinfo
         sudo apt-get install environment-modules likwid
-    - name: Pre-Install (MacOS)
-      if: startsWith(matrix.os, 'macos')
+    - name: Pre-Install (MacOS x86)
+      if: startsWith(matrix.os, 'macos-13')
       run: |
         brew install slurm open-mpi gcc clinfo modules;
+        export PATH="/usr/local/opt/gcc@14/bin":$PATH;
+        export CC=gcc-14; export CXX=g++-14;
+        export FC=gfortran
+    # do not install clinfo as it is broken for macos-14/15
+    - name: Pre-Install (MacOS Arm64)
+      if: startsWith(matrix.os, 'macos') && !contains(matrix.os, 'macos-13')
+        brew install slurm open-mpi gcc modules;
         export PATH="/usr/local/opt/gcc@14/bin":$PATH;
         export CC=gcc-14; export CXX=g++-14;
         export FC=gfortran

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -54,6 +54,7 @@ jobs:
     # do not install clinfo as it is broken for macos-14/15
     - name: Pre-Install (MacOS Arm64)
       if: startsWith(matrix.os, 'macos') && !contains(matrix.os, 'macos-13')
+      run: |
         brew install slurm open-mpi gcc modules;
         export PATH="/usr/local/opt/gcc@14/bin":$PATH;
         export CC=gcc-14; export CXX=g++-14;

--- a/machinestate.py
+++ b/machinestate.py
@@ -3415,6 +3415,7 @@ class OpenCLInfoPlatformClass(ListInfoGroup):
                 suffix = "P0"
             self.const("IcdSuffix", suffix)
             num_devs = process_cmd((clcmd, cmdopts, r".*{}.*#DEVICES\s*(\d+)".format(suffix), int))
+            print(num_devs)
             if num_devs and num_devs > 0:
                 self.userlist = [r for r in range(num_devs)]
                 self.subargs = {"clinfo_path" : clinfo_path, "suffix" : suffix}

--- a/machinestate.py
+++ b/machinestate.py
@@ -3415,7 +3415,6 @@ class OpenCLInfoPlatformClass(ListInfoGroup):
                 suffix = "P0"
             self.const("IcdSuffix", suffix)
             num_devs = process_cmd((clcmd, cmdopts, r".*{}.*#DEVICES\s*(\d+)".format(suffix), int))
-            print(num_devs)
             if num_devs and num_devs > 0:
                 self.userlist = [r for r in range(num_devs)]
                 self.subargs = {"clinfo_path" : clinfo_path, "suffix" : suffix}

--- a/machinestate.py
+++ b/machinestate.py
@@ -563,14 +563,20 @@ class BaseOperation:
         out = data
         if self.regex is not None:
             regex = re.compile(self.regex)
+            m = None
             for l in NEWLINE_REGEX.split(data):
                 m = regex.match(l)
                 if m:
                     out = m.group(1)
+                    break
                 else:
                     m = regex.search(l)
                     if m:
                         out = m.group(1)
+                        break
+            if not m:
+                out = ""
+                self.parser = None
         return out
     def parse(self, data):
         out = data
@@ -3405,6 +3411,8 @@ class OpenCLInfoPlatformClass(ListInfoGroup):
             self.addc("Vendor", clcmd, cmdopts, r"\s+CL_PLATFORM_VENDOR\s+(.+)", str)
             #self.commands["IcdSuffix"] = (clcmd, cmdopts, r"\s+CL_PLATFORM_ICD_SUFFIX_KHR\s+(.+)", str)
             suffix = process_cmd((clcmd, cmdopts, r"\s+CL_PLATFORM_ICD_SUFFIX_KHR\s+(.+)", str))
+            if " " in suffix:
+                suffix = "P0"
             self.const("IcdSuffix", suffix)
             num_devs = process_cmd((clcmd, cmdopts, r".*{}.*#DEVICES\s*(\d+)".format(suffix), int))
             if num_devs and num_devs > 0:

--- a/machinestate.py
+++ b/machinestate.py
@@ -1712,8 +1712,9 @@ class CpuFrequencyMacOsCpu(InfoGroup):
 
     @staticmethod
     def get_ioreg_states(string):
-        bytestr = re.match(r".*<([0-9A-Fa-f]+)>", string).group(1)
+        bytestr = re.match(r".*<([0-9A-Fa-f]+)>", string)
         if bytestr:
+            bytestr = bytestr.group(1)
             # numbers consecutive in 4-byte little-endian
             states_int = struct.unpack("<" + int(len(bytestr)/8) * "i", bytes.fromhex(bytestr))
             # voltage states are in pairs of (freq, voltage)

--- a/machinestate.py
+++ b/machinestate.py
@@ -1713,11 +1713,13 @@ class CpuFrequencyMacOsCpu(InfoGroup):
     @staticmethod
     def get_ioreg_states(string):
         bytestr = re.match(r".*<([0-9A-Fa-f]+)>", string).group(1)
-        # numbers consecutive in 4-byte little-endian
-        states_int = struct.unpack("<" + int(len(bytestr)/8) * "i", bytes.fromhex(bytestr))
-        # voltage states are in pairs of (freq, voltage)
-        states_int = [x for x in states_int if states_int.index(x)%2 == 0 and x > 0]
-        return states_int
+        if bytestr:
+            # numbers consecutive in 4-byte little-endian
+            states_int = struct.unpack("<" + int(len(bytestr)/8) * "i", bytes.fromhex(bytestr))
+            # voltage states are in pairs of (freq, voltage)
+            states_int = [x for x in states_int if states_int.index(x)%2 == 0 and x > 0]
+            return states_int
+        return string
 
 class CpuFrequencyMacOsBus(InfoGroup):
     def __init__(self, extended=False, anonymous=False):


### PR DESCRIPTION
So far, MachineState only supported MacOS on x86 chips.
This PR provides the following features:

- enable support for Apple Silicon (tested on M1)
  - while not every attribute is available on MacOS with Apple Silicon compared to Linux, as much information as possible is retrieved and shown. For clock frequencies we had to go via `ioreg` with the entries `voltage-states1-sram` and `voltage-states5-sram` for the E cores and P cores, respectively.
- fix clinfo output
  - as `clinfo` shows different attributes on different systems (with or without GPU, Intel or non-Intel, etc...), the previous version broke already as some of the regular expressions (such as `CL_DEVICE_SUB_GROUP_SIZES_INTEL` or `CL_DEVICE_MAX_NUM_SUB_GROUPS`) lead to no match and, therefore, created errors during the parsing as MachineState could not convert the string to an integer. This is fixed by setting the output to an empty string in case there was a group given for the regex and no match was found.
- added MacOS to the GH Action workflow
  - MacOS for both x86 and Arm64 was added (again) to the Github Action workflow. Unfortunately, the `clinfo` on the macos-14 and macos-15 runners is broken and throws an error when executing, so there is no clinfo command for those tests; maybe this changes in the future and we can add it again. 

After this PR is accepted, we should consider a new minor release.
