### PR TITLE
Fix nvidia-smi without NVIDIA driver and un-eval'd LMOD output

### DIFF
--- a/machinestate.py
+++ b/machinestate.py
@@ -3200,6 +3200,10 @@ class NvidiaSmiInfo(ListInfoGroup):
         abscmd = which(self.cmd)
         if abscmd:
             num_gpus = process_cmd((self.cmd, self.cmd_opts, r"Attached GPUs\s+:\s+(\d+)", int))
+            if not isinstance(int):
+                # command failed (because nvidia-smi is installed but non-functional)
+                # don't add abcmd to list
+                return
             if num_gpus > 0:
                 self.userlist = [i for i in range(num_gpus)]
                 self.subclass = NvidiaSmiInfoClass

--- a/machinestate.py
+++ b/machinestate.py
@@ -3072,6 +3072,9 @@ class ModulesInfo(InfoGroup):
     @staticmethod
     def parsemodules(value):
         slist = [ x for x in re.split("\n", value) if ";" not in x ]
+        if len(slist) == 0:
+            # workaround for module output `echo '<module/x.y.z>';`
+            slist = [ x.split("'")[1] for x in re.split("\n", value) if "echo" in x and "'" in x ]
         if re.match("^Currently Loaded.+$", slist[0]):
             slist = slist[1:]
         return slist

--- a/machinestate.py
+++ b/machinestate.py
@@ -3200,7 +3200,7 @@ class NvidiaSmiInfo(ListInfoGroup):
         abscmd = which(self.cmd)
         if abscmd:
             num_gpus = process_cmd((self.cmd, self.cmd_opts, r"Attached GPUs\s+:\s+(\d+)", int))
-            if not isinstance(int):
+            if not isinstance(num_gpus, int):
                 # command failed (because nvidia-smi is installed but non-functional)
                 # don't add abcmd to list
                 return

--- a/machinestate.py
+++ b/machinestate.py
@@ -3202,7 +3202,7 @@ class NvidiaSmiInfo(ListInfoGroup):
             num_gpus = process_cmd((self.cmd, self.cmd_opts, r"Attached GPUs\s+:\s+(\d+)", int))
             if not isinstance(num_gpus, int):
                 # command failed (because nvidia-smi is installed but non-functional)
-                # don't add abcmd to list
+                # don't add cmd to list
                 return
             if num_gpus > 0:
                 self.userlist = [i for i in range(num_gpus)]


### PR DESCRIPTION
This PR solves two problems:

**1. nvidia-smi without NVIDIA driver**
While it is common practice to not support nvml without nvidia drivers, there exist systems with installed NVIDIA libraries but no drivers, i.e., `nvidia-smi` is found but does not return a valid output:
```shell
$ nvidia-smi -q
NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver.
Make sure that the latest NVIDIA driver is installed and running.
```

MachineState then fails while proccessing the command as it can't grep "`Attached GPUs\s+:\s+(\d+)`".
This PR fixes this by checking if the output is actually an `int` or failed and returns the stdout/stderr (i.e., `str` output)

**2. un-eval'd LMOD output**
We usually assume, the output of environment modules (`module -t list`) prints all currently-loaded modules such as
```shell
$ module -t list
Currently Loaded Modulefiles:
CCconfig
gentoo/2023
gcccore/.12.3
gcc/12.3
```

However, some versions of `lmod` seem to print the string that has to be `eval`'d:

```shell
$ echo $LMOD_CMD
/.../.../software/lmod/lmod/libexec/lmod
$LMOD_CMD sh -t list

echo 'CCconfig';
echo 'gentoo/2023';
echo 'gcccore/.12.3';
echo 'gcc/12.3';
MODULEPATH=/<OBFUSCATED>.../custom/modules;
export MODULEPATH;
ModuleTable001_=X81vZHV<OBFUSCATED>EVudiA9IHSK;
export ModuleTable001_;
ModuleTable002_=Zm4gPSAIL2N2<OBFUSCATED>wkbG9hZE9yZGVyID8gMTISCnBy;
export ModuleTable002_;
ModuleTable883_=b3BUID0ge <OBFSUCATED>AwMDAwMy4wMDAwMDAwMDEuKnpmaW5hbCIs;
export ModuleTable003_;
...
```

With filtering out all lines with "`;`" (`slist = [ x for x in re.split("\n", value) if ";" not in x ]`), we end up with an empty list.
As a workaround, I currently check for lines with "`echo`" and take the name in the single quotes but there might be a more generic way to do so such as running an "`eval`" command on the output if we detect an "`echo`" and end up with what we got before with `module -t list`.
Maybe it is also enough to run `$LMOD_CMD -t list` instead of the current `$LMOD_CMD sh -t list`? If I have access to a system to test this, I will edit this PR.